### PR TITLE
Allow talk-name org.gtk.vfs.* to open files in SMB and other NFS shares

### DIFF
--- a/org.gnome.gedit.json
+++ b/org.gnome.gedit.json
@@ -11,7 +11,8 @@
         "--socket=wayland",
         "--filesystem=host",
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--talk-name=org.gtk.vfs.*"
     ],
     "build-options" : {
         "cflags": "-O2 -g",


### PR DESCRIPTION
Closes #4