### PR TITLE
Update to 3.30 and remove host permissions

### DIFF
--- a/org.gnome.gedit.json
+++ b/org.gnome.gedit.json
@@ -9,7 +9,6 @@
     "finish-args": [
         "--share=ipc", "--socket=x11",
         "--socket=wayland",
-        "--filesystem=host",
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--talk-name=org.gtk.vfs.*"
@@ -44,8 +43,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.7.tar.xz",
-                    "sha256": "a5c20d3a6347533689358f3ea52486409f6dd41d5a69c65eab7570cfaffee8e6"
+                    "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.9.tar.xz",
+                    "sha256": "699d76a453e6a3d3331906346e3dbfa25f2cbc9ec090e46635e9c6bb595e07c2"
                 }
             ]
         },
@@ -57,8 +56,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.0.tar.xz",
-                    "sha256": "1b7fc2c5b84ede43bc52d513f0601238af92b572a42b19363da6d067fb529345"
+                    "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.1.tar.xz",
+                    "sha256" : "819a1d23c7603000e73f5e738bdd284342e0cd345fb0c7650999c31ec741bbe5"
                 }
             ],
             "modules": [
@@ -82,8 +81,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gedit/3.28/gedit-3.28.1.tar.xz",
-                    "sha256": "f174be0958ce63771fef9a81d06da6769358dab8705364a6abb5c7d10ec8211d"
+                    "url": "https://download.gnome.org/sources/gedit/3.30/gedit-3.30.0.tar.xz",
+                    "sha256": "bd5c26499f988a1d608591beadb4eb408697dc8c2a61cde9909aeec71e2aef79"
                 }
             ]
         }

--- a/org.gnome.gedit.json
+++ b/org.gnome.gedit.json
@@ -9,6 +9,7 @@
     "finish-args": [
         "--share=ipc", "--socket=x11",
         "--socket=wayland",
+        "--filesystem=host",
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--talk-name=org.gtk.vfs.*"


### PR DESCRIPTION
gedit 3.30 now uses the native filechooser so this removes the --host permissions. There may be some visual regressions (lots more paths that say /run/user rather than /home/etc. but much better sandboxing!