### PR TITLE
 Remove redundant build flags

### DIFF
--- a/org.gnome.gedit.json
+++ b/org.gnome.gedit.json
@@ -15,8 +15,6 @@
         "--talk-name=org.gtk.vfs.*"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
         "env": {
             "V": "1"
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.