### PR TITLE
Add fallback-x11

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -8,6 +8,7 @@ command: gedit
 finish-args:
   - "--share=ipc"
   - "--socket=x11"
+  - "--socket=fallback-x11"
   - "--socket=wayland"
   - "--metadata=X-DConf=migrate-path=/org/gnome/gedit/"
   # Needed at least for the integrated file browser plugin:


### PR DESCRIPTION
From the Flatpak Command Reference:

> The fallback-x11 option makes the X11 socket available only if there is no Wayland socket. This option was introduced in 0.11.3. To support older Flatpak releases, specify both x11 and fallback-x11. The fallback-x11 option takes precedence when both are supported.