### PR TITLE
Update app to 41.0 and runtime to Gnome 42

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -83,7 +83,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 1627
-          url-template: https://github.com/libgit2/libgit2/archive/refs/tags/v$version.tar.gz
+          url-template: https://github.com/libgit2/libgit2/archive/v$version/libgit2-$version.tar.gz
 
   - name: libgit2-glib
     buildsystem: meson

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -28,71 +28,6 @@ cleanup:
   - '*.a'
 
 modules:
-  - name: libpeas
-    buildsystem: meson
-    config-opts:
-      - -Dlua51=false
-      - -Dvapi=true
-      - -Ddemos=false
-      - -Dglade_catalog=false
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libpeas/1.32/libpeas-1.32.0.tar.xz
-        sha256: d625520fa02e8977029b246ae439bc218968965f1e82d612208b713f1dcc3d0e
-        x-checker-data:
-          type: gnome
-          name: libpeas
-
-  - name: gspell
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/gspell/1.8/gspell-1.8.4.tar.xz
-        sha256: cf4d16a716e813449bd631405dc1001ea89537b8cdae2b8abfb3999212bd43b4
-        x-checker-data:
-          type: gnome
-          name: gspell
-
-  - name: libgit2
-    buildsystem: cmake
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=None
-      - -Wno-dev
-    sources:
-      - type: archive
-        url: https://github.com/libgit2/libgit2/archive/v1.4.2/libgit2-1.4.2.tar.gz
-        sha256: 901c2b4492976b86477569502a41c31b274b69adc177149c02099ea88404ef19
-        x-checker-data:
-          type: anitya
-          project-id: 1627
-          url-template: https://github.com/libgit2/libgit2/archive/v$version/libgit2-$version.tar.gz
-
-  - name: libgit2-glib
-    buildsystem: meson
-    config-opts:
-      - -Dssh=false
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libgit2-glib/1.0/libgit2-glib-1.0.0.1.tar.xz
-        sha256: 460a5d6936950ca08d2d8518bfc90c12bb187cf6e674de715f7055fc58102b57
-        x-checker-data:
-          type: gnome
-          name: libgit2-glib
-          # TODO: switch to stable in future
-          stable-only: false
-
-  - name: dbus-python
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.2.18.tar.gz
-        sha256: 92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260
-        x-checker-data:
-          type: anitya
-          project-id: 402
-          url-template: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz
-
   - name: gedit
     buildsystem: meson
     sources:
@@ -103,6 +38,33 @@ modules:
           type: gnome
           name: gedit
 
+    modules:
+      - name: gspell
+        cleanup:
+          - /bin
+        sources:
+          - type: archive
+            url: https://download.gnome.org/sources/gspell/1.8/gspell-1.8.4.tar.xz
+            sha256: cf4d16a716e813449bd631405dc1001ea89537b8cdae2b8abfb3999212bd43b4
+            x-checker-data:
+              type: gnome
+              name: gspell
+
+      - name: libpeas
+        buildsystem: meson
+        config-opts:
+          - -Dlua51=false
+          - -Dvapi=true
+          - -Ddemos=false
+          - -Dglade_catalog=false
+        sources:
+          - type: archive
+            url: https://download.gnome.org/sources/libpeas/1.32/libpeas-1.32.0.tar.xz
+            sha256: d625520fa02e8977029b246ae439bc218968965f1e82d612208b713f1dcc3d0e
+            x-checker-data:
+              type: gnome
+              name: libpeas
+
   - name: gedit-plugins
     buildsystem: meson
     sources:
@@ -112,3 +74,44 @@ modules:
         x-checker-data:
           type: gnome
           name: gedit-plugins
+
+    modules:
+      - name: dbus-python
+        buildsystem: autotools
+        sources:
+          - type: archive
+            url: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.2.18.tar.gz
+            sha256: 92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260
+            x-checker-data:
+              type: anitya
+              project-id: 402
+              url-template: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz
+
+      - name: libgit2-glib
+        buildsystem: meson
+        config-opts:
+          - -Dssh=false
+        sources:
+          - type: archive
+            url: https://download.gnome.org/sources/libgit2-glib/1.0/libgit2-glib-1.0.0.1.tar.xz
+            sha256: 460a5d6936950ca08d2d8518bfc90c12bb187cf6e674de715f7055fc58102b57
+            x-checker-data:
+              type: gnome
+              name: libgit2-glib
+              # TODO: switch to stable in future
+              stable-only: false
+
+        modules:
+          - name: libgit2
+            buildsystem: cmake
+            config-opts:
+              - -DCMAKE_BUILD_TYPE=None
+              - -Wno-dev
+            sources:
+              - type: archive
+                url: https://github.com/libgit2/libgit2/archive/v1.4.2/libgit2-1.4.2.tar.gz
+                sha256: 901c2b4492976b86477569502a41c31b274b69adc177149c02099ea88404ef19
+                x-checker-data:
+                  type: anitya
+                  project-id: 1627
+                  url-template: https://github.com/libgit2/libgit2/archive/v$version/libgit2-$version.tar.gz

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -1,6 +1,6 @@
 app-id: org.gnome.gedit
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 command: gedit
 

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -37,8 +37,8 @@ modules:
       - -Dglade_catalog=false
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/libpeas/1.30/libpeas-1.30.0.tar.xz
-        sha256: 0bf5562e9bfc0382a9dcb81f64340787542568762a3a367d9d90f6185898b9a3
+        url: https://download.gnome.org/sources/libpeas/1.32/libpeas-1.32.0.tar.xz
+        sha256: d625520fa02e8977029b246ae439bc218968965f1e82d612208b713f1dcc3d0e
         x-checker-data:
           type: gnome
           name: libpeas
@@ -54,32 +54,15 @@ modules:
           type: gnome
           name: gspell
 
-  - name: amtk
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/amtk/5.2/amtk-5.2.0.tar.xz
-        sha256: 820545bb4cf87ecebc2c3638d6b6e58b8dbd60a419a9b43cf020124e5dad7078
-        x-checker-data:
-          type: gnome
-          name: amtk
-
-  - name: tepl
-    buildsystem: meson
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/tepl/6.00/tepl-6.00.0.tar.xz
-        sha256: a86397a895dca9c0de7a5ccb063bda8f7ef691cccb950ce2cfdee367903e7a63
-        x-checker-data:
-          type: gnome
-          name: tepl
-
   - name: libgit2
     buildsystem: cmake
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=None
+      - -Wno-dev
     sources:
       - type: archive
-        url: https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.0.tar.gz
-        sha256: 192eeff84596ff09efb6b01835a066f2df7cd7985e0991c79595688e6b36444e
+        url: https://github.com/libgit2/libgit2/archive/v1.4.2/libgit2-1.4.2.tar.gz
+        sha256: 901c2b4492976b86477569502a41c31b274b69adc177149c02099ea88404ef19
         x-checker-data:
           type: anitya
           project-id: 1627
@@ -114,8 +97,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gedit/40/gedit-40.1.tar.xz
-        sha256: 55e394a82cb65678b1ab49526cf5bd43f00d8fba21476a4849051a8e137d3691
+        url: https://download.gnome.org/sources/gedit/41/gedit-41.0.tar.xz
+        sha256: 7a9b18b158808d1892989165f3706c4f1a282979079ab7458a79d3c24ad4deb5
         x-checker-data:
           type: gnome
           name: gedit
@@ -124,8 +107,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gedit-plugins/40/gedit-plugins-40.1.tar.xz
-        sha256: dfb7989507a5745cb17c42fb1472207167a387197354f64254118e4a9437c196
+        url: https://download.gnome.org/sources/gedit-plugins/41/gedit-plugins-41.0.tar.xz
+        sha256: a38f949460914f054063671bf0bb8e8a5184e6210be89f64bb304652d4520e87
         x-checker-data:
           type: gnome
           name: gedit-plugins


### PR DESCRIPTION
**Changes**

- Update runtime to Gnome 42
- Update module
  - gedit 41.0
  - gedit-plugins 41.0
  - libpeas 1.32.0
  - libgit2 1.4.2
- Remove amtk and tepl
- Switch to nested dependency tree
- libgit2-glib: use libgit2-$version.tar.gz tarballs in url template for better fedc logging