### PR TITLE
Update gedit to 42.0

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -88,6 +88,49 @@ modules:
               project-id: 402
               url-template: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz
 
+      - name: gucharmap
+        buildsystem: meson
+        config-opts:
+          - -Ducd_path=/app/share/unicode
+        sources:
+          - type: archive
+            url: https://gitlab.gnome.org/GNOME/gucharmap/-/archive/14.0.3/gucharmap-14.0.3.tar.gz
+            sha256: 410b4ff222de5d3c16d47b0c2c268fe03cde1753872a5d5b6c3877a1e87ef284
+            x-checker-data:
+              type: anitya
+              project-id: 1276
+              stable-only: true
+              url-template: https://gitlab.gnome.org/GNOME/gucharmap/-/archive/$version/gucharmap-$version.tar.gz
+        cleanup:
+          - /share/help
+          - /share/metainfo
+        modules:
+          - name: unicode-character-database
+            buildsystem: simple
+            build-commands:
+              - install -Dm644 {UCD,Unihan}.zip -t ${FLATPAK_DEST}/share/unicode/
+              - bsdtar -xf UCD.zip -C ${FLATPAK_DEST}/share/unicode
+              - bsdtar -xf Unihan.zip -C ${FLATPAK_DEST}/share/unicode
+            sources:
+              - type: file
+                url: https://www.unicode.org/Public/zipped/14.0.0/UCD.zip
+                sha256: 033a5276b5d7af8844589f8e3482f3977a8385e71d107d375055465178c23600
+                x-checker-data:
+                  type: anitya
+                  project-id: 17620
+                  stable-only: true
+                  url-template: https://www.unicode.org/Public/zipped/$version/UCD.zip
+              - type: file
+                url: https://www.unicode.org/Public/zipped/14.0.0/Unihan.zip
+                sha256: 2ae4519b2b82cd4d15379c17e57bfb12c33c0f54da4977de03b2b04bcf11852d
+                x-checker-data:
+                  type: anitya
+                  project-id: 17620
+                  stable-only: true
+                  url-template: https://www.unicode.org/Public/zipped/$version/Unihan.zip
+            cleanup:
+              - '*'
+
       - name: libgit2-glib
         buildsystem: meson
         config-opts:

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -35,10 +35,9 @@ modules:
         url: https://download.gnome.org/sources/gedit/41/gedit-41.0.tar.xz
         sha256: 7a9b18b158808d1892989165f3706c4f1a282979079ab7458a79d3c24ad4deb5
         x-checker-data:
-          type: anitya
-          project-id: 5758
+          type: gnome
+          name: gedit
           stable-only: true
-          url-template: https://download.gnome.org/sources/gedit/$version0/gedit-$version.tar.xz
 
     modules:
       - name: gspell

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -32,8 +32,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gedit/41/gedit-41.0.tar.xz
-        sha256: 7a9b18b158808d1892989165f3706c4f1a282979079ab7458a79d3c24ad4deb5
+        url: https://download.gnome.org/sources/gedit/42/gedit-42.0.tar.xz
+        sha256: a87991f42961eb4f6abcdbaabb784760c23aeaeefae6363d3e21a61e9c458437
         x-checker-data:
           type: gnome
           name: gedit


### PR DESCRIPTION
**Changes**
- Update gedit to 42.0. As far as I can tell, 41.0 plugins still work, so this look safe
- gedit: Switch back to Gnome checker. The issue that broke the Gnome checker is now fixed, and `org.flathub.flatpak-external-data-checker` is also updated now.
- Add gucharmap module for getting the Character Map plugin work. Hint: it's hidding in the side-panel.