### PR TITLE
Allow xdg-run/gvfsd access and upate gedit-plugins to 42.0

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -71,8 +71,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gedit-plugins/41/gedit-plugins-41.0.tar.xz
-        sha256: a38f949460914f054063671bf0bb8e8a5184e6210be89f64bb304652d4520e87
+        url: https://download.gnome.org/sources/gedit-plugins/42/gedit-plugins-42.0.tar.xz
+        sha256: 7246420fbc3d3950ef78d2e346e21306440e71c64d74f6e8c44e51a58cd0db62
         x-checker-data:
           type: gnome
           name: gedit-plugins

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -11,7 +11,8 @@ finish-args:
   - --metadata=X-DConf=migrate-path=/org/gnome/gedit/
   # Needed at least for the integrated file browser plugin:
   - --filesystem=host
-  # For opening files from remote locations (with GVfs):
+  # GVfs GIO APIs access using backend URIs
+  - --filesystem=xdg-run/gvfsd
   - --talk-name=org.gtk.vfs.*
 
 cleanup:


### PR DESCRIPTION
Needed for GVfs admin backend with admin:// URIs.
GVfs issue @ https://gitlab.gnome.org/GNOME/gvfs/-/issues/305

Closes #18.

Untested, as I'm not running Gnome desktop environment.