### PR TITLE
gspell: update to 1.14, switch to Meson

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -42,12 +42,18 @@ modules:
 
     modules:
       - name: gspell
-        cleanup:
-          - /bin
+        buildsystem: meson
+        config-opts:
+          - -Dgspell_app=false
+          - -Dgobject_introspection=false
+          - -Dvapi=false
+          - -Dgtk_doc=false
+          - -Dtests=false
+          - -Dinstall_tests=false
         sources:
           - type: archive
-            url: https://download.gnome.org/sources/gspell/1.12/gspell-1.12.2.tar.xz
-            sha256: b4e993bd827e4ceb6a770b1b5e8950fce3be9c8b2b0cbeb22fdf992808dd2139
+            url: https://download.gnome.org/sources/gspell/1.14/gspell-1.14.0.tar.xz
+            sha256: 64ea1d8e9edc1c25b45a920e80daf67559d1866ffcd7f8432fecfea6d0fe8897
             x-checker-data:
               type: gnome
               name: gspell


### PR DESCRIPTION
The cleanup of /bin is no longer needed, thank to
-Dgspell_app=false