### PR TITLE
vte: tune the x-checker-data

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -169,6 +169,7 @@ modules:
               type: gnome
               name: vte
               stable-only: true
+              version-scheme: odd-minor-is-unstable
 
         modules:
           - name: fast_float


### PR DESCRIPTION
The flathubbot tried to update vte-0.80.2.tar.xz to 0.81.0, but 0.81.0 is an unstable release.