### PR TITLE
vte: improve the x-checker-data

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -168,8 +168,8 @@ modules:
             x-checker-data:
               type: gnome
               name: vte
-              versions:
-                <: '0.81'
+              stable-only: true
+              version-scheme: odd-minor-is-unstable
 
         modules:
           - name: fast_float


### PR DESCRIPTION
The bug in flatpak-external-data-checker is fixed: https://github.com/flathub-infra/flatpak-external-data-checker/issues/436