### PR TITLE
Update to gedit 48.1.1

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -43,13 +43,13 @@ modules:
   - name: gedit
     buildsystem: meson
     sources:
-      - type: archive
-        url: https://download.gnome.org/sources/gedit/48/gedit-48.1.tar.xz
-        sha256: 971e7ac26bc0a3a3ded27a7563772415687db0e5a092b4547e5b10a55858b30a
+      - type: git
+        url: https://gitlab.gnome.org/World/gedit/gedit.git
+        tag: 48.1.1
+        commit: 868cfd80b16d699421dfe8910a3b1ee9ddba4280
         x-checker-data:
-          type: gnome
-          name: gedit
-          stable-only: true
+          type: git
+          tag-pattern: ^48\.1\.\d+$
 
     modules:
       - name: gspell


### PR DESCRIPTION
48.2 already exists and removed the Python plugins support.

48.1 and 48.1.* still have the Python plugins.