### PR TITLE
Allow access to USB devices

### DIFF
--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -6,8 +6,7 @@ command: gedit
 
 finish-args:
   # Needed for access to removable disks due to custom open/save dialog
-  - --device=usb
-  - --require-version=1.16.0
+  - --device=all
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland

--- a/org.gnome.gedit.yml
+++ b/org.gnome.gedit.yml
@@ -5,6 +5,9 @@ sdk: org.gnome.Sdk
 command: gedit
 
 finish-args:
+  # Needed for access to removable disks due to custom open/save dialog
+  - --device=usb
+  - --require-version=1.16.0
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland


### PR DESCRIPTION
Removable USB devices don't show up in the open/save dialog because neither of the following is true:
1. Gedit doesn't use the portal dialog via GtkFileChooserNative
2. Gedit doesn't ask for USB device access for its custom dialog

As a result, USB devices connected to the system aren't visible in the user-friendly sidebar of the open/save dialogs, which is a problem.

Resolving the first issue by porting to GtkFileChooserNative seems unlikely anytime soon. It was previously done in
https://gitlab.gnome.org/World/gedit/gedit/-/commit/34419a44bc9f7186278e540d335b7d1b17f54dae, but then then reverted in
https://gitlab.gnome.org/World/gedit/gedit/-/commit/74e0be7e8419d3dbbb6554a9b2315b59b693846e without much movement in resolving this impasse.

As a result, addressing the second issue seems like the more feasible approach.